### PR TITLE
Add github token action parameter

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+name: "docs"
+on:
+  pull_request:
+  push:
+    branches:
+      - "latest"
+
+jobs:
+  check-docs:
+    name: Verify docs are up-to-date
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: (Setup Lix with this action...)
+        uses: ./
+
+      - name: Check docs are up-to-date
+        shell: bash
+        run: |
+          (
+          PS4=" $ "
+          set -eux -o pipefail
+          export LC_CTYPE=en_US.UTF-8
+          support/update-readme.rb --check
+          )

--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ Some differences:
  - We use the `channel:` ref to Nixpkgs instead of the `flake:` ref, as the `flake:` ref may have issues within the GHA ecosystem, regarding rate-limiting.
  - We configure the current user as a trusted user.
 
-### Options
+* * *
+
+Configuring the action
+----------------------
+
+<!-- ACTION.YML INPUTS START -->
 
 #### `github_access_token`
 
@@ -22,6 +27,8 @@ A github token that is added as an entry on extra-access-tokens in nix.conf.
 
 By default, the `github.token` is configured. See https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
 for a description of the default token's permissions.
+
+<!-- ACTION.YML INPUTS END -->
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ Configuring the action
 
 <!-- ACTION.YML INPUTS START -->
 
-#### `github_access_token`
+### `github_access_token`
 
 A github token that is added as an entry on extra-access-tokens in nix.conf.
 
 By default, the `github.token` is configured. See https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
 for a description of the default token's permissions.
+
 
 <!-- ACTION.YML INPUTS END -->
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,15 @@ Some differences:
  - We use the `channel:` ref to Nixpkgs instead of the `flake:` ref, as the `flake:` ref may have issues within the GHA ecosystem, regarding rate-limiting.
  - We configure the current user as a trusted user.
 
-No options.
+### Options
 
-* * *
+#### `github_access_token`
+
+A github token that is added as an entry on extra-access-tokens in nix.conf.
+
+By default, the `github.token` is configured. See https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+for a description of the default token's permissions.
+
+---
 
 <sup>1</sup>: And checks Nix is available, and also wraps with error reporting...

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,18 @@
 name: Lix GHA Installer Action
-description: Simple action to install Lix (the independent variant of the Nix package manager). 
+description: Simple action to install Lix (the independent variant of the Nix package manager).
+inputs:
+  github_access_token:
+    description: |
+      A github token that is added as an entry on extra-access-tokens in nix.conf.
+
+      By default, the `github.token` is configured. See https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+      for a description of the default token's permissions.
 runs:
   using: "composite"
   steps:
     - name: Install Lix
       run: bash ${{ github.action_path }}/do-the-lix-thing
       shell: bash
+      env:
+        INPUT_GITHUB_ACCESS_TOKEN: "${{inputs.github_access_token}}"
+        GITHUB_TOKEN: "${{github.token}}"

--- a/do-the-lix-thing
+++ b/do-the-lix-thing
@@ -130,6 +130,13 @@ curl -sSf -L https://install.lix.systems/lix | bash -s -- install --no-confirm
 
 (
 	< /etc/nix/nix.conf sed -e 's/nixpkgs=flake:nixpkgs/nixpkgs=channel:nixos-unstable/'
+	if [ -z "${INPUT_GITHUB_ACCESS_TOKEN:-}" ]; then
+		echo "Configuring default github access token" >&2
+		printf "extra-access-tokens = github.com=%s\n" "${GITHUB_TOKEN}"
+	else
+		echo "Configuring custom github access token" >&2
+		printf "extra-access-tokens = github.com=%s\n" "${INPUT_GITHUB_ACCESS_TOKEN}"
+	fi
 	printf "trusted-users = root %s\n" "${USER:-}"
 ) > tmp.conf
 sudo mv -v tmp.conf /etc/nix/nix.conf

--- a/support/update-readme.rb
+++ b/support/update-readme.rb
@@ -1,0 +1,63 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p ruby
+#!nix-shell -i ruby
+
+require "yaml"
+
+CHECK = ARGV.include?("--check")
+
+def marker(which, direction)
+  "<!-- ACTION.YML #{which.upcase} #{direction.upcase} -->"
+end
+
+def replace_markers(str, which, content)
+  str.gsub(
+    %r{#{marker(which, "start")}.*#{marker(which, "end")}}m,
+    [
+      marker(which, "start"),
+      "",
+      content,
+      "",
+      marker(which, "end"),
+    ].join("\n")
+  )
+end
+
+TOP = File.join(__dir__(), "..")
+README = File.join(TOP, "README.md")
+ACTION = File.join(TOP, "action.yml")
+
+action_data = YAML.load(File.read(ACTION))
+formatted_inputs = action_data["inputs"].map do |key, data|
+  [
+    "### `#{key}`",
+    if data["default"] then [
+        "",
+        "*Default: `#{data["default"]}`*",
+    ] else [] end,
+    "",
+    data["description"]
+  ].flatten().join("\n")
+end.join("\n\n")
+
+readme = File.read(README)
+new_contents = replace_markers(readme, "inputs", formatted_inputs)
+
+unless readme == new_contents
+  if CHECK
+    message = [
+      "NOTE: generated README sections differ from current README.",
+      "      run support/update-readme.rb to update, and then make a new commit.",
+    ].join("\n")
+    $stderr.puts ""
+    $stderr.puts %Q{::error title="Documentation is not up-to-date!"::#{message.gsub("\n", "%0A")}}
+    $stderr.puts ""
+    $stderr.puts message
+    exit 1
+  else
+    File.write(README, new_contents)
+  end
+end
+
+
+#vim ft=ruby


### PR DESCRIPTION
This PR adds a `github_access_token` parameter to the action, which then sets that token up as an `extra-access-tokens` entry for github.com. If no token is given, the action now configures the GHA workflow run's token, which allows a greater rate limit than unauthenticated operation.

Allowing custom tokens allows even greater rate limits, and access to private repos that the token has access to.