### PR TITLE
Add an extra nix config parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./
+        with:
+          extra_nix_config: |
+            extra-access-tokens = example.com=lix-gha-installer-extra-config-works
       - name: Printing some useful info
         shell: bash
         run: |
@@ -36,5 +39,6 @@ jobs:
         run: |
           (
           set -eux -o pipefail
+          nix --extra-experimental-features nix-command config show | grep lix-gha-installer-extra-config-works
           echo "pp RUBY_DESCRIPTION" | nix-shell -p ruby --run ruby
           )

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ By default, the `github.token` is configured. See https://docs.github.com/en/act
 for a description of the default token's permissions.
 
 
+### `extra_nix_config`
+
+Additional configuration text to append to nix.conf. See https://docs.lix.systems/manual/lix/2.90/command-ref/conf-file.html
+for a description of the config file format.
+
+
 <!-- ACTION.YML INPUTS END -->
 
 ---

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
 
       By default, the `github.token` is configured. See https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
       for a description of the default token's permissions.
+  extra_nix_config:
+    description: |
+      Additional configuration text to append to nix.conf. See https://docs.lix.systems/manual/lix/2.90/command-ref/conf-file.html
+      for a description of the config file format.
 runs:
   using: "composite"
   steps:
@@ -16,3 +20,4 @@ runs:
       env:
         INPUT_GITHUB_ACCESS_TOKEN: "${{inputs.github_access_token}}"
         GITHUB_TOKEN: "${{github.token}}"
+        INPUT_EXTRA_CONFIG: "${{inputs.extra_nix_config}}"

--- a/do-the-lix-thing
+++ b/do-the-lix-thing
@@ -138,6 +138,7 @@ curl -sSf -L https://install.lix.systems/lix | bash -s -- install --no-confirm
 		printf "extra-access-tokens = github.com=%s\n" "${INPUT_GITHUB_ACCESS_TOKEN}"
 	fi
 	printf "trusted-users = root %s\n" "${USER:-}"
+	echo "${INPUT_EXTRA_CONFIG:-}"
 ) > tmp.conf
 sudo mv -v tmp.conf /etc/nix/nix.conf
 )


### PR DESCRIPTION
I needed to add some config parameters for my personal repos (caching config, mostly), and added these clauses to my personal fork. This has worked pretty well so far, so I thought I'd upstream it.

The Readme updated perfectly with the input-documenting script, by the way (: