### PR TITLE
Cache lix installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ By default, the `github.token` is configured. See https://docs.github.com/en/act
 for a description of the default token's permissions.
 
 
+### `extra_nix_config`
+
+Additional configuration text to append to nix.conf. See https://docs.lix.systems/manual/lix/2.90/command-ref/conf-file.html
+for a description of the config file format.
+
+
 <!-- ACTION.YML INPUTS END -->
 
 ---

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
 
       By default, the `github.token` is configured. See https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
       for a description of the default token's permissions.
+  extra_nix_config:
+    description: |
+      Additional configuration text to append to nix.conf. See https://docs.lix.systems/manual/lix/2.90/command-ref/conf-file.html
+      for a description of the config file format.
 runs:
   using: "composite"
   steps:
@@ -16,3 +20,4 @@ runs:
       env:
         INPUT_GITHUB_ACCESS_TOKEN: "${{inputs.github_access_token}}"
         GITHUB_TOKEN: "${{github.token}}"
+        INPUT_EXTRA_CONFIG: "${{inputs.extra_nix_config}}"

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Cache installer
+      uses: actions/cache@v4
+      with:
+        path: /tmp/lix-installer
+        key: lix-installer-${{ runner.os }}-${{ runner.arch }}
     - name: Install Lix
       run: bash ${{ github.action_path }}/do-the-lix-thing
       shell: bash

--- a/do-the-lix-thing
+++ b/do-the-lix-thing
@@ -138,6 +138,7 @@ curl -sSf -L https://install.lix.systems/lix | bash -s -- install --no-confirm
 		printf "extra-access-tokens = github.com=%s\n" "${INPUT_GITHUB_ACCESS_TOKEN}"
 	fi
 	printf "trusted-users = root %s\n" "${USER:-}"
+	echo "${INPUT_EXTRA_CONFIG:-}"
 ) > tmp.conf
 sudo mv -v tmp.conf /etc/nix/nix.conf
 )

--- a/do-the-lix-thing
+++ b/do-the-lix-thing
@@ -16,6 +16,7 @@ set -o pipefail # the return value of a pipeline is the status of
 # Constants
 REPO_URL="https://github.com/samueldr/lix-gha-installer-action"
 ACTION_NAME="Lix GHA Installer Action"
+INSTALLER_DOWNLOAD_DIR="/tmp/lix-installer"
 ################################################################################
 
 
@@ -126,7 +127,15 @@ trap _handle_exit EXIT
 (
 set -x
 
-curl -sSf -L https://install.lix.systems/lix | bash -s -- install --no-confirm
+_installer_bin="$INSTALLER_DOWNLOAD_DIR/lix-installer"
+_etag="$INSTALLER_DOWNLOAD_DIR/etag"
+mkdir -p "$(dirname "$_installer_bin")"
+if ! [ -f "$_etag" ] || ! curl --head -sSf -L --etag-compare "$_etag" "https://install.lix.systems/lix/lix-installer-$(_get_system)"
+then
+	curl -o "$_installer_bin" -sSf -L --etag-save "$_etag" "https://install.lix.systems/lix/lix-installer-$(_get_system)"
+	chmod +x "$_installer_bin"
+fi
+"$_installer_bin" install --no-confirm
 
 (
 	< /etc/nix/nix.conf sed -e 's/nixpkgs=flake:nixpkgs/nixpkgs=channel:nixos-unstable/'


### PR DESCRIPTION
This PR attempts to address #4 by replicating the functionality of the download-and-run installer script ([as it advises users do](https://git.lix.systems/lix-project/lix-installer/src/branch/main/lix-installer.sh#L4-L6)), adding etag cache invalidation.

It then uses the "actions/cache" action to store the etag value and the lix installer the GHA cache.