### PR TITLE
Pin cache action with full revision identifier

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache installer
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # @v4.3.0
       with:
         path: /tmp/lix-installer
         key: lix-installer-${{ runner.os }}-${{ runner.arch }}


### PR DESCRIPTION
This is what I prefer, first of all, and also fixes an issue for organizations where pinning the actions through the git revision identifier is enforced.

* * *

This had been asked of me out of band.