### PR TITLE
action: Ensure kvm is usable by the builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,35 @@ jobs:
           set -eux -o pipefail
           nix --extra-experimental-features nix-command config show
           )
+      - name: Checking kvm is setup
+        shell: bash
+        run: |
+          (
+            set -eu -o pipefail
+            if test -e /dev/kvm; then
+              echo "/dev/kvm is present."
+              if test -e /dev/kvm; then
+                echo "/dev/kvm is accessible."
+                if (set -x; nix --extra-experimental-features nix-command config show | grep '^system-features =.*kvm'); then
+                  echo "kvm is setup as a system feature."
+                else
+                  echo "kvm has not been setup as a system feature!"
+                  echo "Aborting..."
+                  exit 1
+                fi
+              else
+                echo "/dev/kvm is not accessible!"
+                echo "Aborting..."
+                exit 1
+              fi
+            else
+              echo "No /dev/kvm... this is possibly fine."
+              (
+                set -x
+                uname -a
+              )
+            fi
+          )
       - name: Doing some Nix stuff
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,13 @@ jobs:
           env | grep -i nix
           cat /etc/nix/nix.conf
           )
+      - name: nix config show
+        shell: bash
+        run: |
+          (
+          set -eux -o pipefail
+          nix --extra-experimental-features nix-command config show
+          )
       - name: Doing some Nix stuff
         shell: bash
         run: |

--- a/do-the-lix-thing
+++ b/do-the-lix-thing
@@ -122,6 +122,15 @@ printf '\n'
 
 trap _handle_exit EXIT
 
+if test -e /dev/kvm; then
+	echo "Setting-up /dev/kvm..."
+	if (set -x; sudo chmod a+rw /dev/kvm); then
+		echo "... Done!"
+	else
+		echo "... Couldn't be done?"
+	fi
+fi
+
 # Start tracing commands
 # Doing it in a subshell means _handle_exit will not trace.
 (


### PR DESCRIPTION
I've been told that `kvm`, while sometimes available on builders, is not setup so it's available by default to "jobs" automatically.

Instead, it seems the expectation is CI would reconfigure the system, with well-cargo-culted commands, so the KVM node is made accessible.

Instead of using the cargo-culted command, let's just `chmod` the device node. No need to re-trigger the whole of `udev` for a new rule... When the end-result is just a long detour to make a `chmod` happen.

Additionally, there is no sniffing of the host platform, or anything of the sort. This entirely relies on feature detection: Is the node there? Then change its mode. A failure to change its mode is logged, but not an overall failure.

* * *

This PR:

 - Makes the `/dev/kvm` node available to any system user, when present
 - Adds CI checks, to verify the change is working.