### PR TITLE
Output more information after install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+        os: # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#standard-github-hosted-runners-for-public-repositories
+          # Linux systems
           - ubuntu-22.04
           - ubuntu-24.04
           - ubuntu-22.04-arm
           - ubuntu-24.04-arm
-          - macos-13 # Last x86_64
+          # macOS systems
           - macos-14 # aarch64
           - macos-15 # aarch64
+          - macos-26 # aarch64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/do-the-lix-thing
+++ b/do-the-lix-thing
@@ -73,6 +73,10 @@ _command_exists() {
 	type -P "$1" > /dev/null
 }
 
+_indent() {
+	sed -e 's/^/    /'
+}
+
 _environment_details() {
 	printf "Environment details:\n"
 	printf "  - Date:     %s\n" "$(date)"
@@ -180,8 +184,11 @@ set +u
 set -u
 
 # Then do some additional checks
-printf '\n  builtins.nixVersion: ';
-(set -x; nix-instantiate --eval --json --strict --expr "(builtins.nixVersion)")
-printf '\n'
+printf '\n  builtins.nixVersion:\n';
+(set -x; nix-instantiate --eval --json --strict --expr "(builtins.nixVersion)") 2>&1 | _indent
 
+printf '\n  Lix version information:\n'
+(set -x; nix-instantiate --version) 2>&1 | _indent
+
+printf '\n'
 rm -v "$TRACE_LOG" "$ERR_LOG" || true

--- a/do-the-lix-thing
+++ b/do-the-lix-thing
@@ -183,6 +183,10 @@ set +u
 
 set -u
 
+# See if nix thinks the install is good...
+printf '\n  nix doctor:\n'
+(set -x; nix doctor) 2>&1 | _indent
+
 # Then do some additional checks
 printf '\n  builtins.nixVersion:\n';
 (set -x; nix-instantiate --eval --json --strict --expr "(builtins.nixVersion)") 2>&1 | _indent


### PR DESCRIPTION
Fixes #13.

The logs now include something that looks like:

```
Checking install...

  nix doctor:
    Running checks against store uri daemon
    [PASS] PATH contains only one nix version.
    [PASS] All profiles are gcroots.
    [PASS] Client protocol matches store protocol.
    [INFO] You are trusted by store uri: daemon
    [FAIL] Error: current generation cannot be discovered for profile: '/home/runner/.local/state/nix/profiles/profile'
    

  builtins.nixVersion:
    "2.18.3-lix"

  Lix version information:
    nix-instantiate (Lix, like Nix) 2.94.0
    System type: x86_64-linux
    Additional system types: i686-linux, x86_64-v1-linux, x86_64-v2-linux, x86_64-v3-linux
    Features: gc, signed-caches
    System configuration file: /etc/nix/nix.conf
    User configuration files: /home/runner/.config/nix/nix.conf:/etc/xdg/nix/nix.conf
    Store directory: /nix/store
    State directory: /nix/var/nix
    Data directory: /nix/store/vr4a39d4bw01793jl4qap839rlvmc143-lix-2.94.0/share
```

That one failure in the `nix doctor` output is benign, and related to the “profiles” feature, which is unlikely to be needed in a CI situation.