### PR TITLE
Fix etag comparison to actually download when etag is out of date for cached lix-installer

### DIFF
--- a/do-the-lix-thing
+++ b/do-the-lix-thing
@@ -167,11 +167,8 @@ set -x
 _installer_bin="$INSTALLER_DOWNLOAD_DIR/lix-installer"
 _etag="$INSTALLER_DOWNLOAD_DIR/etag"
 mkdir -p "$(dirname "$_installer_bin")"
-if ! [ -f "$_etag" ] || ! curl --head -sSf -L --etag-compare "$_etag" "https://install.lix.systems/lix/lix-installer-$(_get_system)"
-then
-	curl -o "$_installer_bin" -sSf -L --etag-save "$_etag" "https://install.lix.systems/lix/lix-installer-$(_get_system)"
-	chmod +x "$_installer_bin"
-fi
+curl --output "$_installer_bin" --silent --show-error --fail --location --etag-compare "$_etag" --etag-save "$_etag" "https://install.lix.systems/lix/lix-installer-$(_get_system)"
+chmod +x "$_installer_bin"
 "$_installer_bin" install --no-confirm
 
 (


### PR DESCRIPTION
Since `curl -f --etag-compare` does not actually change status code for HTTP 200 vs 304, doing a bash `if` does not actually work for determining when a new download needs to occur and so once any lix-installer version is cached then that version will be used indefinitely (because the `curl` invocation will always return success even if out of date unless there is some brief/transient network error or 4xx/5xx HTTP error)

Using both `--etag-save` and `--etag-compare` in the same invocation is supported and recommended by the curl project for only downloading a file when it needs to be updated and gracefully handles when the etag file does not already exist (and so handles all of the previously intended (but non-working) functionality)

I've also taken the opportunity to expand all of the single-letter flags as recommended/desired by @samueldr :)